### PR TITLE
Add build.tools to readthedocs config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,8 @@ version: 2
 # Build environment
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.7"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -22,7 +24,6 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt
     - method: setuptools


### PR DESCRIPTION
Second attempt at closing #48. 

I think I have now included all the required elements for the `.readthedocs.yml` file based on https://docs.readthedocs.io/en/stable/config-file/v2.html.